### PR TITLE
Localize link picker

### DIFF
--- a/src/App_Plugins/GibeLinkPicker/Dialogs/linkpicker.html
+++ b/src/App_Plugins/GibeLinkPicker/Dialogs/linkpicker.html
@@ -10,10 +10,10 @@
 		               ng-disabled="target.id"/>
 		    </umb-control-group>
 
-            <umb-control-group label="Hash Target">
+            <umb-control-group label="@Gibe.LinkPicker_hashTarget">
                 <input type="text"
                        localize="placeholder"
-                       placeholder="Enter a hash target..."
+                       placeholder="@Gibe.LinkPicker_enterHashTarget"
                        class="umb-editor umb-textstring"
                        ng-model="target.hashtarget" />
             </umb-control-group>
@@ -29,9 +29,7 @@
 			<umb-control-group label="@content_target">
 				<select class="umb-editor umb-dropdown" ng-model="target.target">
 					<option value=""></option>
-					<option value="_blank">Opens the linked document in a new window or tab</option>
-					<option value="_top">Opens the linked document in the full body of the window</option>
-					<option value="_parent">Opens the linked document in the parent frame</option>
+					<option value="_blank"><localize key="defaultdialogs_openInNewWindow">Opens the linked document in a new window or tab</localize></option>
 				</select>
 			</umb-control-group>
 		</umb-pane>
@@ -70,11 +68,11 @@
 	        		<localize key="general_cancel">Cancel</localize>
 				</a>
 
-				<a href ng-click="switchToMediaPicker()" class="btn">Link to file</a>
+				<a href ng-click="switchToMediaPicker()" class="btn">
+					<localize key="defaultdialogs_linkToFile">Link to file</localize>
+				</a>
 
-				<button
-					class="btn btn-primary"
-					ng-click="submit(target)">
+				<button class="btn btn-primary" ng-click="submit(target)">
 					<localize key="buttons_select">Select</localize>
 				</button>
 	        </div>

--- a/src/App_Plugins/GibeLinkPicker/Lang/da-DK.xml
+++ b/src/App_Plugins/GibeLinkPicker/Lang/da-DK.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+	<area alias="Gibe.LinkPicker">
+		<key alias="enterHashTarget">Indtast et hash target</key>
+		<key alias="hashTarget">Hash target</key>
+	</area>
+</language>

--- a/src/App_Plugins/GibeLinkPicker/Lang/en-GB.xml
+++ b/src/App_Plugins/GibeLinkPicker/Lang/en-GB.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+	<area alias="Gibe.LinkPicker">
+		<key alias="enterHashTarget">Enter a hash target</key>
+		<key alias="hashTarget">Hash target</key>
+	</area>
+</language>

--- a/src/App_Plugins/GibeLinkPicker/Lang/en-US.xml
+++ b/src/App_Plugins/GibeLinkPicker/Lang/en-US.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+	<area alias="Gibe.LinkPicker">
+		<key alias="enterHashTarget">Enter a hash target</key>
+		<key alias="hashTarget">Hash target</key>
+	</area>
+</language>

--- a/src/App_Plugins/GibeLinkPicker/picker.html
+++ b/src/App_Plugins/GibeLinkPicker/picker.html
@@ -7,7 +7,9 @@
             <a class="edit" href="" ng-click="editLink()"><i class="icon icon-edit"></i></a>
 		</p>
 		<p class="internal-picker" ng-hide="model.value">
-			<a class="link" href="" ng-click="chooseLink()">Choose</a>
+			<a class="link" href="" ng-click="chooseLink()">
+				<localize key="general_choose">Choose</localize>
+			</a>
 		</p>
 	</div>
 


### PR DESCRIPTION
Issue: https://github.com/Gibe/Umbraco-Link-Picker/issues/22

I have added some further localization and remove the target options `_top` and `_parent` (I don't think any editors use these values and Umbraco has also removed these values from core. I could also be changed to a checkbox like it is in Umbraco 7.6+ - but it seems the the linkpicker dialog (used in e.g. richtext editor I think) use the dropdownlist.
https://github.com/umbraco/Umbraco-CMS/blob/ef0d6eff2ce4ab0bcdfb806b514fcceb2df6f01e/src/Umbraco.Web.UI.Client/src/views/common/dialogs/linkpicker.html#L25

while the new linkpicker overlay use checkbox:
https://github.com/umbraco/Umbraco-CMS/blob/ef0d6eff2ce4ab0bcdfb806b514fcceb2df6f01e/src/Umbraco.Web.UI.Client/src/views/common/overlays/linkpicker/linkpicker.html#L21-L25
