### PR TITLE
Update link picker to match Umbraco 7.6 style

### DIFF
--- a/src/App_Plugins/GibeLinkPicker/picker.css
+++ b/src/App_Plugins/GibeLinkPicker/picker.css
@@ -4,12 +4,6 @@
 	padding: 0;
 }
 
-.gibe-link-picker .chosen
-{
-	margin: 0;
-	padding: 0;
-}
-
 .gibe-link-picker .internal-picker
 {
 	margin: 0;

--- a/src/App_Plugins/GibeLinkPicker/picker.html
+++ b/src/App_Plugins/GibeLinkPicker/picker.html
@@ -1,14 +1,20 @@
 ﻿<div ng-controller="Gibe.LinkPickerController">
 
 	<div class="gibe-link-picker">
-		<p class="chosen" ng-show="model.value">
-		    <a href="{{model.value.url}}" target="_blank">{{model.value.name || model.value.url}}</a>
-		    <a class="remove" href="" ng-click="removeLink()"><i class="icon icon-delete"></i></a>
-            <a class="edit" href="" ng-click="editLink()"><i class="icon icon-edit"></i></a>
-		</p>
-		<p class="internal-picker" ng-hide="model.value">
-			<a class="link" href="" ng-click="chooseLink()">Choose</a>
-		</p>
+		<div class="umb-node-preview" ng-show="model.value">
+			<div class="umb-node-preview__content">
+			    <i ng-if="icon" class="umb-node-preview__icon {{icon}}"></i>
+				<div class="umb-node-preview__name ng-binding">{{model.value.name || model.value.url}}</div>
+				<div ng-if="model.value.name && model.value.url" class="umb-node-preview__description">{{model.value.url}}</div>
+			</div>
+			<div class="umb-node-preview__actions">
+				<a class="umb-node-preview__action" title="Edit" href="" ng-click="editLink()"><localize key="general_edit">Edit</localize></a>
+				<a class="umb-node-preview__action umb-node-preview__action--red" title="Remove" href="" ng-click="removeLink()"><localize key="general_remove">Remove</localize></i></a>
+			</div>
+		</div>
+		<div class="internal-picker" ng-hide="model.value">
+			<a class="link umb-node-preview-add" href="" ng-click="chooseLink()">Choose</a>
+		</div>
 	</div>
 
 </div>


### PR DESCRIPTION
Issue: https://github.com/Gibe/Umbraco-Link-Picker/issues/24

I have updated the styles to match the new pickers in Umbraco 7.6+ without using `umb-node-preview` component. In pre Umbraco 7.6 versions the classes shouldn't have any effect, but you might to style in a bit for pre Umbraco 7.6 versions.

It also need a value for `icon` property in scope. Maybe consider to use store all properties on a `$scope.model`.