### PR TITLE
Change target framework to 4.5 to align with Umbraco

### DIFF
--- a/src/Gibe.LinkPicker.Umbraco/Gibe.LinkPicker.Umbraco.csproj
+++ b/src/Gibe.LinkPicker.Umbraco/Gibe.LinkPicker.Umbraco.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Gibe.LinkPicker.Umbraco</RootNamespace>
     <AssemblyName>Gibe.LinkPicker.Umbraco</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -131,7 +132,7 @@
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="Semver, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\semver.1.1.2\lib\net451\Semver.dll</HintPath>
+      <HintPath>..\packages\semver.1.1.2\lib\net45\Semver.dll</HintPath>
     </Reference>
     <Reference Include="SQLCE4Umbraco, Version=1.0.6471.23741, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\UmbracoCms.Core.7.6.8\lib\net45\SQLCE4Umbraco.dll</HintPath>

--- a/src/Gibe.LinkPicker.Umbraco/app.config
+++ b/src/Gibe.LinkPicker.Umbraco/app.config
@@ -46,4 +46,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/src/Gibe.LinkPicker.Umbraco/packages.config
+++ b/src/Gibe.LinkPicker.Umbraco/packages.config
@@ -32,7 +32,7 @@
   <package id="MySql.Data" version="6.9.10" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
-  <package id="semver" version="1.1.2" targetFramework="net461" />
+  <package id="semver" version="1.1.2" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Dataflow" version="4.7.0" targetFramework="net461" />
   <package id="UmbracoCms.Core" version="7.6.8" targetFramework="net461" />


### PR DESCRIPTION
Umbraco still uses .NET 4.5 as target framework. Link Picker uses 4.6.1 which causes issues when including it in a project. As there is no code in the project that requires 4.6.1, I see no reason to not just use 4.5 instead.