### PR TITLE
Fixed Issue with Internal Links

### DIFF
--- a/src/Gibe.LinkPicker.Umbraco/PropertyConverters/LinkPickerValueConverter.cs
+++ b/src/Gibe.LinkPicker.Umbraco/PropertyConverters/LinkPickerValueConverter.cs
@@ -40,9 +40,17 @@ namespace Gibe.LinkPicker.Umbraco.PropertyConverters
 
             var sourceString = source.ToString();
 
+            var umbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+
             try
             {
-                var linkPicker = JsonConvert.DeserializeObject<Models.LinkPicker>(sourceString);
+                Models.LinkPicker linkPicker = JsonConvert.DeserializeObject<Models.LinkPicker>(sourceString);
+
+                if(linkPicker.Id > 0)
+                {
+                    linkPicker.Url = umbracoHelper.TypedContent(linkPicker.Id).Url;
+                }
+
 
                 return linkPicker;
             }

--- a/src/Gibe.LinkPicker.Umbraco/PropertyConverters/LinkPickerValueConverter.cs
+++ b/src/Gibe.LinkPicker.Umbraco/PropertyConverters/LinkPickerValueConverter.cs
@@ -48,9 +48,8 @@ namespace Gibe.LinkPicker.Umbraco.PropertyConverters
 
                 if(linkPicker.Id > 0)
                 {
-                    linkPicker.Url = umbracoHelper.TypedContent(linkPicker.Id).Url;
+                    linkPicker.Url = umbracoHelper.TypedContent(linkPicker.Id)?.Url ?? linkPicker.Url;
                 }
-
 
                 return linkPicker;
             }


### PR DESCRIPTION
This fix resolves an issue where if having a link picker with an internal page picked, then afterwards updating the page name (and therefore the url of that page) the link picker used to still use only the saved value, i have added this so that if an internal page is selected then it will query the cache and use the url from there instead.