### PR TITLE
tweak when evaluating if a udi is null

### DIFF
--- a/src/Gibe.LinkPicker.Umbraco/PropertyConverters/LinkPickerValueConverter.cs
+++ b/src/Gibe.LinkPicker.Umbraco/PropertyConverters/LinkPickerValueConverter.cs
@@ -46,7 +46,7 @@ namespace Gibe.LinkPicker.Umbraco.PropertyConverters
             {
                 var linkPicker = JsonConvert.DeserializeObject<Models.LinkPicker>(sourceString);
 
-                if(linkPicker.Id > 0 || linkPicker.Udi != null)
+                if(linkPicker.Id > 0 || !string.IsNullOrWhiteSpace(linkPicker.Udi))
                 {
                     var content =
                         linkPicker.Udi != null


### PR DESCRIPTION
i ran into a problem where the value converter was throwing the following exception when using an external link:

`Gibe.LinkPicker.Umbraco.PropertyConverters.LinkPickerValueConverter - String "" is not a valid udi`

it seems that if you change the link picker value in the backoffice from an internal to an external link the guid is an empty string rather than a null...

based on the debugging i've done locally, checking using a 'IsNullOrWhiteSpace' gets round the problem.